### PR TITLE
Correct zoom-in, zoom-out mouse wheel directions

### DIFF
--- a/src/raphael.pan-zoom.js
+++ b/src/raphael.pan-zoom.js
@@ -105,8 +105,8 @@
                 delta = evt.detail ? evt.detail : evt.wheelDelta * -1,
                 zoomCenter = getRelativePosition(evt, container);
 
-            if (delta < 0) delta = -1;
-            else if (delta > 0) delta = 1;
+            if (delta > 0) delta = -1;
+            else if (delta < 0) delta = 1;
             
             applyZoom(delta, zoomCenter);
             if (evt.preventDefault) evt.preventDefault();


### PR DESCRIPTION
Tested it in Chrome and Firefox 11. 

Zoom in is scroll up and zoom out is scroll down.
