### PR TITLE
Check to see if we're allowed to drag in the dragging function

### DIFF
--- a/src/raphael.pan-zoom.js
+++ b/src/raphael.pan-zoom.js
@@ -132,6 +132,7 @@
         this.applyZoom = applyZoom;
 
         function dragging(e) {
+            if (!me.enabled) return false;
             var evt = window.event || e,
                 newWidth = paper.width * (1 - (me.currZoom * settings.zoomStep)),
                 newHeight = paper.height * (1 - (me.currZoom * settings.zoomStep)),


### PR DESCRIPTION
Ran into an issue where I'm implementing callbacks with your library (I disable panzoom once I start moving, but not before). This fixes it. 

Checked your example (the complete map) and it still works... so I hope I didn't break anything :P
